### PR TITLE
Support for Mermaid.js in kaleido

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ repos/CREDITS.html
 venv/*
 repos/old_src_third_party*/*
 repos/.gclient_previous_sync_commits
+.vscode/*

--- a/mermaid-playground.py
+++ b/mermaid-playground.py
@@ -1,0 +1,13 @@
+from kaleido.scopes.mermaid import MermaidScope
+
+scope = MermaidScope()
+
+graphDefinition = """
+    graph LR
+    A --- B
+    B-->C[fa:fa-ban forbidden]
+    B-->D(fa:fa-spinner);
+    """
+
+data = scope.transform(graphDefinition, format="svg")
+print(data)

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,11 @@
+./repos/linux_scripts/build_kaleido x64
+source venv/bin/activate
+sudo chmod a+rwx . -R
+
+cd ./repos/kaleido/py
+pip install .
+
+cd ../../../
+cp ./repos/build/kaleido venv/lib/python3.10/site-packages/kaleido -r
+rm venv/lib/python3.10/site-packages/kaleido/executable -r
+mv venv/lib/python3.10/site-packages/kaleido/kaleido venv/lib/python3.10/site-packages/kaleido/executable 

--- a/repos/kaleido/cc/kaleido.cc
+++ b/repos/kaleido/cc/kaleido.cc
@@ -560,12 +560,15 @@ void OnHeadlessBrowserStarted(headless::HeadlessBrowser* browser) {
         if (tagUrl.is_valid()) {
             // Value is a url, use a src of script tag
             htmlStringStream << "<script type=\"text/javascript\" src=\"" << tagValue << "\"></script>";
-        } else if  (kaleido::utils::isScriptModule(tagValue)) {
-            // Value is a module, use a type="module" script tag
-            htmlStringStream << "<script type=\"module\">" << tagValue << "</script>\n";
         } else {
-            // Value is not a url nor a module, use a inline JavaScript code
-            htmlStringStream << "<script>" << tagValue << "</script>\n";
+            if  (kaleido::utils::containsImportStatement(tagValue)) {
+                // Value is a module, use a type="module" script tag
+                htmlStringStream << "<script type=\"module\">" << tagValue << "</script>\n";
+            }
+            else {
+                // Value is not a url nor a module, use a inline JavaScript code
+                htmlStringStream << "<script>" << tagValue << "</script>\n";
+            }
         }
         scriptTags.pop_front();
     }

--- a/repos/kaleido/cc/kaleido.cc
+++ b/repos/kaleido/cc/kaleido.cc
@@ -560,6 +560,8 @@ void OnHeadlessBrowserStarted(headless::HeadlessBrowser* browser) {
         if (tagUrl.is_valid()) {
             // Value is a url, use a src of script tag
             htmlStringStream << "<script type=\"text/javascript\" src=\"" << tagValue << "\"></script>";
+        } else if  (tagValue.find("import") != std::string::npos && tagValue.find("+esm") != std::string::npos) {
+            htmlStringStream << "<script type=\"module\">" << tagValue << "</script>\n";
         } else {
             // Value is not a url, use a inline JavaScript code
             htmlStringStream << "<script>" << tagValue << "</script>\n";

--- a/repos/kaleido/cc/kaleido.cc
+++ b/repos/kaleido/cc/kaleido.cc
@@ -560,10 +560,11 @@ void OnHeadlessBrowserStarted(headless::HeadlessBrowser* browser) {
         if (tagUrl.is_valid()) {
             // Value is a url, use a src of script tag
             htmlStringStream << "<script type=\"text/javascript\" src=\"" << tagValue << "\"></script>";
-        } else if  (tagValue.find("import") != std::string::npos && tagValue.find("+esm") != std::string::npos) {
+        } else if  (kaleido::utils::isScriptModule(tagValue)) {
+            // Value is a module, use a type="module" script tag
             htmlStringStream << "<script type=\"module\">" << tagValue << "</script>\n";
         } else {
-            // Value is not a url, use a inline JavaScript code
+            // Value is not a url nor a module, use a inline JavaScript code
             htmlStringStream << "<script>" << tagValue << "</script>\n";
         }
         scriptTags.pop_front();

--- a/repos/kaleido/cc/scopes/Factory.h
+++ b/repos/kaleido/cc/scopes/Factory.h
@@ -4,6 +4,7 @@
 
 #include "base/strings/string_util.h"
 
+#include "Mermaid.h"
 #include "Plotly.h"
 #include "Base.h"
 
@@ -14,6 +15,8 @@ kaleido::scopes::BaseScope* LoadScope(std::string name) {
     std::string name_lower = base::ToLowerASCII(name);
     if (name_lower == "plotly") {
         return new kaleido::scopes::PlotlyScope();
+    } else if (name_lower == "mermaid") {
+        return new kaleido::scopes::MermaidScope();
     } else {
         return nullptr;
     }

--- a/repos/kaleido/cc/scopes/Mermaid.h
+++ b/repos/kaleido/cc/scopes/Mermaid.h
@@ -1,0 +1,54 @@
+//
+// Created by coma007 on 4/4/24.
+//
+#include "Base.h"
+#include "base/bind.h"
+#include "base/command_line.h"
+#include "base/strings/string_util.h"
+#include "base/strings/stringprintf.h"
+#include "headless/public/devtools/domains/runtime.h"
+#include "../utils.h"
+#include <streambuf>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <fstream>
+
+#ifndef CHROMIUM_MERMAIDSCOPE_H
+#define CHROMIUM_MERMAIDSCOPE_H
+
+namespace kaleido {
+    namespace scopes {
+
+        class MermaidScope : public BaseScope {
+        public:
+            MermaidScope();
+
+            ~MermaidScope() override;
+
+            MermaidScope(const MermaidScope &v);
+
+            std::string ScopeName() override;
+
+            std::vector<std::unique_ptr<::headless::runtime::CallArgument>> BuildCallArguments() override;
+
+        };
+
+        MermaidScope::MermaidScope()  {}
+
+        MermaidScope::~MermaidScope() {}
+
+        MermaidScope::MermaidScope(const MermaidScope &v) {}
+
+        std::string MermaidScope::ScopeName() {
+            return "mermaid";
+        }
+
+        std::vector<std::unique_ptr<::headless::runtime::CallArgument>> MermaidScope::BuildCallArguments() {
+            std::vector<std::unique_ptr<::headless::runtime::CallArgument>> args;
+            return args;
+        }
+    }
+}
+
+#endif //CHROMIUM_MERMAIDSCOPE_H

--- a/repos/kaleido/cc/scopes/Mermaid.h
+++ b/repos/kaleido/cc/scopes/Mermaid.h
@@ -36,13 +36,22 @@ namespace kaleido {
 
         MermaidScope::MermaidScope()  {
 
+            // Initialize mermaid object code
+            std::string mermaidInit = "mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;";
+
             // Process mermaidjs
             if (HasCommandLineSwitch("mermaidjs")) {
                 std::string mermaidjsArg = GetCommandLineSwitch("mermaidjs");
 
                 // Check if value is a URL
                 GURL mermaidjsUrl(mermaidjsArg);
-                if (mermaidjsUrl.is_valid() || (mermaidjsArg.find("import") != std::string::npos && mermaidjsArg.find("+esm") != std::string::npos)) {
+                if (mermaidjsUrl.is_valid()) {
+                    scriptTags.push_back(mermaidjsArg);
+                } else if (mermaidjsArg.find("import") != std::string::npos && mermaidjsArg.find("+esm") != std::string::npos) {
+                    // Add mermaid object initialization
+                    if (mermaidjsArg.find("mermaid.initialize") == std::string::npos) {
+                        mermaidjsArg += "; " + mermaidInit;
+                    }
                     scriptTags.push_back(mermaidjsArg);
                 } else {
                     // Check if this is a local file path
@@ -55,11 +64,8 @@ namespace kaleido {
                     }
                 }
             } else {
-                scriptTags.emplace_back("import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/+esm';");
+                scriptTags.emplace_back("import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/+esm'; " + mermaidInit);
             }
-
-            // Initialize mermaid object
-            scriptTags.emplace_back("mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;");
 
         }
 

--- a/repos/kaleido/cc/scopes/Mermaid.h
+++ b/repos/kaleido/cc/scopes/Mermaid.h
@@ -47,10 +47,10 @@ namespace kaleido {
                 GURL mermaidjsUrl(mermaidjsArg);
                 if (mermaidjsUrl.is_valid()) {
                     // ESM module
-                    if (mermaidjsArg.find("+esm") != std::string::npos) {
+                    if (kaleido::utils::isESModule(mermaidjsArg)) {
                         scriptTags.push_back("import mermaid from '" + mermaidjsArg + "'" + mermaidInit);
                     }
-                    // CDN module
+                    // Default module
                     else {
                         scriptTags.push_back(mermaidjsArg + mermaidInit);
                     }

--- a/repos/kaleido/cc/scopes/Mermaid.h
+++ b/repos/kaleido/cc/scopes/Mermaid.h
@@ -59,7 +59,7 @@ namespace kaleido {
             }
 
             // Initialize mermaid object
-            scriptTags.emplace_back("mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;")
+            scriptTags.emplace_back("mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;");
 
         }
 

--- a/repos/kaleido/cc/scopes/Mermaid.h
+++ b/repos/kaleido/cc/scopes/Mermaid.h
@@ -32,12 +32,13 @@ namespace kaleido {
 
             std::vector<std::unique_ptr<::headless::runtime::CallArgument>> BuildCallArguments() override;
 
+            std::string mermaidConfig;
         };
 
-        MermaidScope::MermaidScope()  {
+        MermaidScope::MermaidScope() : mermaidConfig() {
 
             // Initialize mermaid object code
-            std::string mermaidInit = "; mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;";
+            std::string mermaidInit = "; window.mermaid = mermaid;";
 
             // Process mermaidjs
             if (HasCommandLineSwitch("mermaidjs")) {
@@ -68,11 +69,16 @@ namespace kaleido {
                 scriptTags.emplace_back("import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/+esm'" + mermaidInit);
             }
 
+
+            // Process mermaid-config
+            if (HasCommandLineSwitch("mermaid-config")) {
+                mermaidConfig = GetCommandLineSwitch("mermaid-config");
+            }
         }
 
         MermaidScope::~MermaidScope() {}
 
-        MermaidScope::MermaidScope(const MermaidScope &v) {}
+        MermaidScope::MermaidScope(const MermaidScope &v) : mermaidConfig(v.mermaidConfig)  {}
 
         std::string MermaidScope::ScopeName() {
             return "mermaid";
@@ -80,6 +86,14 @@ namespace kaleido {
 
         std::vector<std::unique_ptr<::headless::runtime::CallArgument>> MermaidScope::BuildCallArguments() {
             std::vector<std::unique_ptr<::headless::runtime::CallArgument>> args;
+
+            // Add mermaid config from command line
+            args.push_back(
+                    headless::runtime::CallArgument::Builder()
+                            .SetValue(std::make_unique<base::Value>(base::StringPiece(mermaidConfig)))
+                            .Build()
+            );
+
             return args;
         }
     }

--- a/repos/kaleido/cc/scopes/Mermaid.h
+++ b/repos/kaleido/cc/scopes/Mermaid.h
@@ -37,7 +37,7 @@ namespace kaleido {
         MermaidScope::MermaidScope()  {
 
             // Initialize mermaid object code
-            std::string mermaidInit = "mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;";
+            std::string mermaidInit = "; mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;";
 
             // Process mermaidjs
             if (HasCommandLineSwitch("mermaidjs")) {
@@ -46,13 +46,14 @@ namespace kaleido {
                 // Check if value is a URL
                 GURL mermaidjsUrl(mermaidjsArg);
                 if (mermaidjsUrl.is_valid()) {
-                    scriptTags.push_back(mermaidjsArg);
-                } else if (mermaidjsArg.find("import") != std::string::npos && mermaidjsArg.find("+esm") != std::string::npos) {
-                    // Add mermaid object initialization
-                    if (mermaidjsArg.find("mermaid.initialize") == std::string::npos) {
-                        mermaidjsArg += "; " + mermaidInit;
+                    // ESM module
+                    if (mermaidjsArg.find("+esm") != std::string::npos) {
+                        scriptTags.push_back("import mermaid from '" + mermaidjsArg + "'" + mermaidInit);
                     }
-                    scriptTags.push_back(mermaidjsArg);
+                    // CDN module
+                    else {
+                        scriptTags.push_back(mermaidjsArg + mermaidInit);
+                    }
                 } else {
                     // Check if this is a local file path
                     if (std::ifstream(mermaidjsArg)) {
@@ -64,7 +65,7 @@ namespace kaleido {
                     }
                 }
             } else {
-                scriptTags.emplace_back("import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/+esm'; " + mermaidInit);
+                scriptTags.emplace_back("import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/+esm'" + mermaidInit);
             }
 
         }

--- a/repos/kaleido/cc/scopes/Mermaid.h
+++ b/repos/kaleido/cc/scopes/Mermaid.h
@@ -34,7 +34,34 @@ namespace kaleido {
 
         };
 
-        MermaidScope::MermaidScope()  {}
+        MermaidScope::MermaidScope()  {
+
+            // Process mermaidjs
+            if (HasCommandLineSwitch("mermaidjs")) {
+                std::string mermaidjsArg = GetCommandLineSwitch("mermaidjs");
+
+                // Check if value is a URL
+                GURL mermaidjsUrl(mermaidjsArg);
+                if (mermaidjsUrl.is_valid() || (mermaidjsArg.find("import") != std::string::npos && mermaidjsArg.find("+esm") != std::string::npos)) {
+                    scriptTags.push_back(mermaidjsArg);
+                } else {
+                    // Check if this is a local file path
+                    if (std::ifstream(mermaidjsArg)) {
+                        localScriptFiles.emplace_back(mermaidjsArg);
+                    } else {
+                        errorMessage = base::StringPrintf("--mermaidjs argument is not a valid URL or file path: %s",
+                                                          mermaidjsArg.c_str());
+                        return;
+                    }
+                }
+            } else {
+                scriptTags.emplace_back("import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/+esm';");
+            }
+
+            // Initialize mermaid object
+            scriptTags.emplace_back("mermaid.initialize( { startOnLoad: false, securityLevel: 'loose'} ); window.mermaid = mermaid;")
+
+        }
 
         MermaidScope::~MermaidScope() {}
 

--- a/repos/kaleido/cc/utils.h
+++ b/repos/kaleido/cc/utils.h
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <regex>
 
 #ifndef CHROMIUM_UTILS_H
 #define CHROMIUM_UTILS_H
@@ -22,8 +23,14 @@ namespace kaleido {
             std::cout << error;
         }
 
-        bool isScriptModule(std::string scriptTag) {
-            return scriptTag.find("import") != std::string::npos;
+        bool containsImportStatement(std::string scriptTag) {
+            std::regex pattern(R"(\bimport\b)");
+            return std::regex_search(scriptTag, pattern);
+        }
+
+        bool isESModule(std::string scriptTag) {
+            std::regex pattern(R"(\b\w+\.esm\b)");
+            return std::regex_search(scriptTag, pattern);
         }
     }
 }

--- a/repos/kaleido/cc/utils.h
+++ b/repos/kaleido/cc/utils.h
@@ -21,6 +21,10 @@ namespace kaleido {
                     code, message.c_str(), version.c_str());
             std::cout << error;
         }
+
+        bool isScriptModule(std::string scriptTag) {
+            return scriptTag.find("import") != std::string::npos;
+        }
     }
 }
 

--- a/repos/kaleido/cc/utils.h
+++ b/repos/kaleido/cc/utils.h
@@ -23,14 +23,20 @@ namespace kaleido {
             std::cout << error;
         }
 
+        bool endsWith(const std::string& fullString, const std::string& ending) 
+        { 
+            if (ending.size() > fullString.size()) 
+                return false; 
+            return fullString.compare(fullString.size() - ending.size(), ending.size(), ending) == 0; 
+        } 
+
         bool containsImportStatement(std::string scriptTag) {
             std::regex pattern(R"(\bimport\b)");
             return std::regex_search(scriptTag, pattern);
         }
 
         bool isESModule(std::string scriptTag) {
-            std::regex pattern(R"(\b\w+\.esm\b)");
-            return std::regex_search(scriptTag, pattern);
+            return endsWith(scriptTag, "+esm");
         }
     }
 }

--- a/repos/kaleido/js/package.json
+++ b/repos/kaleido/js/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "fast-isnumeric": "^1.1.4",
     "is-plain-obj": "^2.1.0",
+    "object.hasown": "^1.1.3",
     "semver": "^7.3.2"
   },
   "devDependencies": {

--- a/repos/kaleido/js/src/index.js
+++ b/repos/kaleido/js/src/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     name: 'kaleido_scopes',
     plotly: require('./plotly/render'),
+    mermaid: require('./mermaid/render'),
     // Additional plugins go here
 }

--- a/repos/kaleido/js/src/mermaid/render.js
+++ b/repos/kaleido/js/src/mermaid/render.js
@@ -16,10 +16,6 @@ if (!Object.hasOwn) {
  *  - scale
  */
 function render (info) {
-
-  // Rename info.data to info.markdown
-  info.markdown = info.data
-  delete info.data;
   
   let errorCode = 0
   let result = null
@@ -47,7 +43,7 @@ function render (info) {
 
   // TODO create different rendering call for v<10 and v>=10 of mermaidjs ?
 
-  promise = mermaid.render("graph", info.markdown)
+  promise = mermaid.render("graph", info.data)
 
   let exportPromise = promise.then((imgData) => {
     result = imgData.svg

--- a/repos/kaleido/js/src/mermaid/render.js
+++ b/repos/kaleido/js/src/mermaid/render.js
@@ -1,11 +1,25 @@
 /* global Mermaid:false */
 
 const semver = require('semver')
+const hasOwn = require('object.hasown')
+
+if (!Object.hasOwn) {
+	hasOwn.shim();
+}
 
 /**
-
+ * @param {object} info : info object
+ *  - data
+ *  - format
+ *  - width
+ *  - height
+ *  - scale
  */
-function render () {
+function render (info) {
+
+  // Rename info.data to info.markdown
+  info.markdown = info.data
+  delete info.data;
   
   let errorCode = 0
   let result = null
@@ -18,22 +32,23 @@ function render () {
     }
 
     return {
-    // TODO this is hardcoded 
       code: errorCode,
       message: errorMsg,
       pdfBgColor,
-      format: "svg",
+      format: info.format,
       result,
-      width: 200,
-      height: 200,
-      scale: 1,
+      width: info.width,
+      height: info.height,
+      scale: info.scale,
     }
   }
 
-  let promise = Promise.resolve("TO DO");
+  let promise
+
+  promise = mermaid.render("graph", info.data)
 
   let exportPromise = promise.then((imgData) => {
-    result = imgData
+    result = imgData.svg
     return done()
   })
 

--- a/repos/kaleido/js/src/mermaid/render.js
+++ b/repos/kaleido/js/src/mermaid/render.js
@@ -45,7 +45,9 @@ function render (info) {
 
   let promise
 
-  promise = mermaid.render("graph", info.data)
+  // TODO create different rendering call for v<10 and v>=10 of mermaidjs ?
+
+  promise = mermaid.render("graph", info.markdown)
 
   let exportPromise = promise.then((imgData) => {
     result = imgData.svg

--- a/repos/kaleido/js/src/mermaid/render.js
+++ b/repos/kaleido/js/src/mermaid/render.js
@@ -14,8 +14,12 @@ if (!Object.hasOwn) {
  *  - width
  *  - height
  *  - scale
+ * @param {string} mermaidConfig: mermaid initialization config object
  */
-function render (info) {
+function render (info, mermaidConfig) {
+
+  mermaidConfigObject = JSON.parse(mermaidConfig)
+  mermaid.initialize( mermaidConfigObject ); 
   
   let errorCode = 0
   let result = null

--- a/repos/kaleido/js/src/mermaid/render.js
+++ b/repos/kaleido/js/src/mermaid/render.js
@@ -1,0 +1,49 @@
+/* global Mermaid:false */
+
+const semver = require('semver')
+
+/**
+
+ */
+function render () {
+  
+  let errorCode = 0
+  let result = null
+  let errorMsg = null
+  let pdfBgColor = null
+  
+  const done = () => {
+    if (errorCode !== 0 && !errorMsg) {
+      errorMsg = cst.statusMsg[errorCode]
+    }
+
+    return {
+    // TODO this is hardcoded 
+      code: errorCode,
+      message: errorMsg,
+      pdfBgColor,
+      format: "svg",
+      result,
+      width: 200,
+      height: 200,
+      scale: 1,
+    }
+  }
+
+  let promise = Promise.resolve("TO DO");
+
+  let exportPromise = promise.then((imgData) => {
+    result = imgData
+    return done()
+  })
+
+  return exportPromise
+      .catch((err) => {
+        errorCode = 525
+        errorMsg = err.message
+        result = null;
+        return done()
+      })
+}
+
+module.exports = render

--- a/repos/kaleido/py/kaleido/scopes/mermaid.py
+++ b/repos/kaleido/py/kaleido/scopes/mermaid.py
@@ -1,0 +1,45 @@
+from kaleido.scopes.base import BaseScope, which
+import base64
+
+
+class MermaidScope(BaseScope):
+    """
+    Scope for transforming Mermaid figures to static images
+    """
+    _all_formats = ("svg")
+    _text_formats = ("svg")
+
+    _scope_flags = ()
+    _scope_chromium_args = ("--no-sandbox",)
+
+    def __init__(self, **kwargs):
+        pass
+        super(MermaidScope, self).__init__(**kwargs)
+
+
+    @property
+    def scope_name(self):
+        return "mermaid"
+
+    
+    def transform(self, markdown, format):
+        """
+        Convert a Mermaid markdown into a static image
+        """
+        response = self._perform_transform(markdown)
+
+        code = response.get("code", 0)
+        if code != 0:
+            message = response.get("message", None)
+            raise ValueError(
+                "Transform failed with error code {code}: {message}".format(
+                    code=code, message=message
+                )
+            )
+
+        img = response.get("result").encode("utf-8")
+
+        if format not in self._text_formats:
+            img = base64.b64decode(img)
+
+        return img

--- a/repos/kaleido/py/kaleido/scopes/mermaid.py
+++ b/repos/kaleido/py/kaleido/scopes/mermaid.py
@@ -1,4 +1,4 @@
-from kaleido.scopes.base import BaseScope, which
+from kaleido.scopes.base import BaseScope
 import base64
 
 

--- a/repos/kaleido/py/kaleido/scopes/mermaid.py
+++ b/repos/kaleido/py/kaleido/scopes/mermaid.py
@@ -9,24 +9,67 @@ class MermaidScope(BaseScope):
     _all_formats = ("svg")
     _text_formats = ("svg")
 
-    _scope_flags = ()
+    _scope_flags = ("mermaidjs")
     _scope_chromium_args = ("--no-sandbox",)
 
-    def __init__(self, **kwargs):
-        pass
-        super(MermaidScope, self).__init__(**kwargs)
+    def __init__(self, mermaidjs, **kwargs):
+        
+        self._mermaidjs = mermaidjs
 
+        self.default_format = "png"
+        self.default_width = 700
+        self.default_height = 500
+        self.default_scale = 1
+        
+        super(MermaidScope, self).__init__(**kwargs)
 
     @property
     def scope_name(self):
         return "mermaid"
 
     
-    def transform(self, markdown, format):
+    def transform(self, markdown, format, width=None, height=None, scale=None):
         """
         Convert a Mermaid markdown into a static image
+
+        :param markdown: Plotly figure or figure dictionary
+        :param format: The desired image format. For now, just 'svg' is supported.
+           
+        :param width: The width of the exported image in layout pixels.
+            If the `scale` property is 1.0, this will also be the width
+            of the exported image in physical pixels.
+
+            If not specified, will default to the `scope.default_width` property
+        :param height: The height of the exported image in layout pixels.
+            If the `scale` property is 1.0, this will also be the height
+            of the exported image in physical pixels.
+
+            If not specified, will default to the `scope.default_height` property
+        :param scale: The scale factor to use when exporting the figure.
+            A scale factor larger than 1.0 will increase the image resolution
+            with respect to the figure's layout pixel dimensions. Whereas as
+            scale factor of less than 1.0 will decrease the image resolution.
+
+            If not specified, will default to the `scope.default_scale` property
+        :return: image bytes
         """
-        response = self._perform_transform(markdown)
+        format = format.lower() if format is not None else self.default_format
+        width = width if width is not None else self.default_width
+        height = height if height is not None else self.default_height
+        scale = scale if scale is not None else self.default_scale
+
+        if format not in self._all_formats:
+            supported_formats_str = repr(list(self._all_formats))
+            raise ValueError(
+                "Invalid format '{original_format}'.\n"
+                "    Supported formats: {supported_formats_str}"
+                .format(
+                    original_format=format,
+                    supported_formats_str=supported_formats_str
+                )
+            )
+
+        response = self._perform_transform(markdown, format=format, width=width, height=height, scale=scale)
 
         code = response.get("code", 0)
         if code != 0:
@@ -43,3 +86,16 @@ class MermaidScope(BaseScope):
             img = base64.b64decode(img)
 
         return img
+    
+
+    @property
+    def mermaidjs(self):
+        """
+        URL or local file path to mermaid.js bundle to use for image export.
+        If not specified, will default to CDN location.
+        """
+        return self._mermaidjs
+
+    @mermaidjs.setter
+    def mermaidjs(self, val):
+        self._mermaidjs = val

--- a/repos/kaleido/py/kaleido/scopes/mermaid.py
+++ b/repos/kaleido/py/kaleido/scopes/mermaid.py
@@ -1,5 +1,6 @@
 from kaleido.scopes.base import BaseScope
-import base64
+import json
+import shlex
 
 
 class MermaidScope(BaseScope):
@@ -9,19 +10,26 @@ class MermaidScope(BaseScope):
     _all_formats = ("svg")
     _text_formats = ("svg")
 
-    _scope_flags = ("mermaidjs",)
+    _scope_flags = ("mermaidjs", "mermaid_config")
     _scope_chromium_args = ("--no-sandbox",)
 
-    def __init__(self, mermaidjs=None, **kwargs):
-        
-        self._mermaidjs = mermaidjs
+    def __init__(self, mermaidjs=None, mermaid_config=None, **kwargs):
+
+        self._mermaidjs = mermaidjs 
 
         self.default_format = "svg"
         self.default_width = 700
         self.default_height = 500
         self.default_scale = 1
+        self.default_mermaid_config = {"startOnLoad": False, "securityLevel": "loose"}
+
+        self._initialize_mermaid_config(mermaid_config)
         
         super(MermaidScope, self).__init__(**kwargs)
+
+    def _initialize_mermaid_config(self, mermaid_config):
+        self._mermaid_config = mermaid_config if mermaid_config is not None else self.default_mermaid_config
+        self._mermaid_config = json.dumps(self._mermaid_config).replace(" ", "") 
 
     @property
     def scope_name(self):
@@ -100,3 +108,16 @@ class MermaidScope(BaseScope):
     @mermaidjs.setter
     def mermaidjs(self, val):
         self._mermaidjs = val
+
+    
+    @property
+    def mermaid_config(self):
+        """
+        Config object for mermaid initialization. 
+        If not specified, default mermaid configuration will be used.
+        """
+        return self._mermaid_config
+
+    @mermaid_config.setter
+    def mermaid_config(self, val):
+        self._mermaid_config = val

--- a/repos/kaleido/py/kaleido/scopes/mermaid.py
+++ b/repos/kaleido/py/kaleido/scopes/mermaid.py
@@ -16,7 +16,7 @@ class MermaidScope(BaseScope):
         
         self._mermaidjs = mermaidjs
 
-        self.default_format = "png"
+        self.default_format = "svg"
         self.default_width = 700
         self.default_height = 500
         self.default_scale = 1
@@ -32,7 +32,7 @@ class MermaidScope(BaseScope):
         """
         Convert a Mermaid markdown into a static image
 
-        :param markdown: Plotly figure or figure dictionary
+        :param markdown: Mermaid graph definition in markdown
         :param format: The desired image format. For now, just 'svg' is supported.
            
         :param width: The width of the exported image in layout pixels.
@@ -53,11 +53,13 @@ class MermaidScope(BaseScope):
             If not specified, will default to the `scope.default_scale` property
         :return: image bytes
         """
+       
+
         format = format.lower() if format is not None else self.default_format
         width = width if width is not None else self.default_width
         height = height if height is not None else self.default_height
         scale = scale if scale is not None else self.default_scale
-
+ 
         if format not in self._all_formats:
             supported_formats_str = repr(list(self._all_formats))
             raise ValueError(

--- a/repos/kaleido/py/kaleido/scopes/mermaid.py
+++ b/repos/kaleido/py/kaleido/scopes/mermaid.py
@@ -9,10 +9,10 @@ class MermaidScope(BaseScope):
     _all_formats = ("svg")
     _text_formats = ("svg")
 
-    _scope_flags = ("mermaidjs")
+    _scope_flags = ("mermaidjs",)
     _scope_chromium_args = ("--no-sandbox",)
 
-    def __init__(self, mermaidjs, **kwargs):
+    def __init__(self, mermaidjs=None, **kwargs):
         
         self._mermaidjs = mermaidjs
 
@@ -28,7 +28,7 @@ class MermaidScope(BaseScope):
         return "mermaid"
 
     
-    def transform(self, markdown, format, width=None, height=None, scale=None):
+    def transform(self, markdown, format=None, width=None, height=None, scale=None):
         """
         Convert a Mermaid markdown into a static image
 

--- a/repos/kaleido/py/kaleido/scopes/mermaid.py
+++ b/repos/kaleido/py/kaleido/scopes/mermaid.py
@@ -84,8 +84,7 @@ class MermaidScope(BaseScope):
 
         img = response.get("result").encode("utf-8")
 
-        if format not in self._text_formats:
-            img = base64.b64decode(img)
+        # TODO add decodings for non-text image formats
 
         return img
     


### PR DESCRIPTION
I added new scope that would support the rendering of [Mermaid](https://mermaid.js.org/) graphing library. For now, only `svg` image format is enabled. I might add other image formats later.

---

What I did:
* Added all the necessary files for scope pipeline (read [official documentation](https://github.com/plotly/Kaleido/wiki/Scope-(Plugin)-Architecture) for more).
* Added support for `<script type="module">` tags in `repos\kaleido\cc\kaleido.cc`. This can be used when scope is delivered via esm.

What I need to do:
* Add support for different versions of mermaid cdn. View Mermaid's [changelog](https://github.com/mermaid-js/mermaid/blob/develop/CHANGELOG.md).
* Add support for different image formats.  

---

This is usage example:
```python
from kaleido.scopes.mermaid import MermaidScope

scope = MermaidScope()

graphDefinition = """
    graph LR
    A --- B
    B-->C[fa:fa-ban forbidden]
    B-->D(fa:fa-spinner);
    """

data = scope.transform(graphDefinition, format="svg")
print(data)
```
Method `scope.transform(markdown, **kwargs)` accepts [mermaid markdown](https://mermaid.js.org/intro/syntax-reference.html) and returns `svg` code in string.

